### PR TITLE
Merge grasshopper-ui and addresspoints API into single Docker-hosted site

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ The site can also be run as a Docker container.  It hosts an CentOS Nginx server
 
 1. Build grasshopper-ui static site.
 
-    grunt build
+        grunt build
 
 1. Build the grasshopper-ui Docker image.
 
-    docker build --rm -t hmda/grasshopper-ui .
+        docker build --rm -t hmda/grasshopper-ui .
 
 1. Start a grasshopper-ui Docker container:
 
-    docker run -p 80:80 hmda/grasshopper-ui
+        docker run -p 80:80 hmda/grasshopper-ui
 
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -50,18 +50,30 @@ The site should now be live at `http://127.0.0.1:4000/grasshopper-ui/dist/`.
 
 ### Docker
 
-The site can also be run as a Docker container. First make sure that the site is built by issuing `grunt build`. Once this is done, build the Docker image as follows:
+The site can also be run as a Docker container.  It hosts an CentOS Nginx server that merges the grasshopper addresspoints API and grasshopper-ui static site into a single site.
 
-```
-docker build --rm -t hmda/grasshopper-ui .
+**Note:** This is currently a very manual process, and geared towards a boot2docker dev environment.  A simpler, more generic Docker setup is coming soon.
 
-```
+1. Add the Elasticsearch and grasshopper addresspoints Docker images.  Follow
+   the instructions from the grasshopper project:
 
-To run the Docker container:
+    * https://github.com/cfpb/grasshopper/tree/master/addresspoints#running
 
-```
-docker run -p 80:80 hmda/grasshopper-ui
-```
+1. Import test data into Elasticsearch using the grasshopper-loader:
+
+    * https://github.com/cfpb/grasshopper-loader#usage
+
+1. Build grasshopper-ui static site.
+
+    grunt build
+
+1. Build the grasshopper-ui Docker image.
+
+    docker build --rm -t hmda/grasshopper-ui .
+
+1. Start a grasshopper-ui Docker container:
+
+    docker run -p 80:80 hmda/grasshopper-ui
 
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The site should now be live at `http://127.0.0.1:4000/grasshopper-ui/dist/`.
 
 ### Docker
 
-The site can also be run as a Docker container.  It hosts an CentOS Nginx server that merges the grasshopper addresspoints API and grasshopper-ui static site into a single site.
+The site can also be run as a Docker container.  It hosts a CentOS Nginx server that merges the grasshopper addresspoints API and grasshopper-ui static site into a single site.
 
 **Note:** This is currently a very manual process, and geared towards a boot2docker dev environment.  A simpler, more generic Docker setup is coming soon.
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,15 +3,41 @@ events {
   accept_mutex off; # "on" if nginx worker_processes > 1
 }
 
+error_log /dev/stdout info;
+
 http {
+  
   include  mime.types;
+  #keepalive_timeout 0;
+
+  upstream http_backend {
+    # Uses the default boot2docker IP and default Port used
+    # by grasshopper addresspoints API.  A smarter/dynamic
+    # host/IP setup is coming soon.
+    server 192.168.59.103:8080;
+  } 
+
   server {
-    listen      80;
+    listen 80;
+    access_log /dev/stdout;
   
     location / {
       autoindex on;
       root /opt/grasshopper-ui;
     }
+
+    location /api/ {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;                        
+      proxy_pass http://http_backend/;
+
+      # Default CentOS Nginx install does not include proxy_params file, 
+      # but probably worth creating one as we add proxy-specific settings
+      #include /etc/nginx/proxy_params;
+    }
+
   }
 
 }
+


### PR DESCRIPTION
Similar to the local dev setup on https://github.com/cfpb/grasshopper-ui/pull/49, this merges the grasshopper-ui static site with the grasshopper addresspoints API into a single site via Nginx, hosted in a Docker container.

This is currently geared towards a boot2docker local setup.  IP/ports/etc. will have to be updated prior to being deployed to an alternate environment.  A more flexible setup is coming soon.
