### PR TITLE
Merge all APIs under /api via Nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,14 +8,28 @@ error_log /dev/stdout info;
 http {
   
   include  mime.types;
-  #keepalive_timeout 0;
 
-  upstream http_backend {
-    # Uses the default boot2docker IP and default Port used
-    # by grasshopper addresspoints API.  A smarter/dynamic
-    # host/IP setup is coming soon.
-    server 192.168.59.103:8080;
-  } 
+  # Default CentOS Nginx install does not include proxy_params file, 
+  # but probably worth creating one as we add proxy-specific settings
+  #include /etc/nginx/proxy_params;
+
+  # Upstreams uses the default Docker Compose host names and ports.
+  # A smarter/dynamic host/IP setup is coming soon.
+  upstream geocoder {
+    server geocoder:8080;
+  }
+
+  upstream points {
+    server points:8081;
+  }
+
+  upstream lines {
+    server lines:8082;
+  }
+
+  upstream parser {
+    server parser:5000;
+  }
 
   server {
     listen 80;
@@ -26,15 +40,32 @@ http {
       root /opt/grasshopper-ui;
     }
 
-    location /api/ {
+    location /api/geocoder/ {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;                        
-      proxy_pass http://http_backend/;
+      proxy_pass http://geocoder/;
+    }
 
-      # Default CentOS Nginx install does not include proxy_params file, 
-      # but probably worth creating one as we add proxy-specific settings
-      #include /etc/nginx/proxy_params;
+    location /api/lines/ {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;                        
+      proxy_pass http://lines/;
+    }
+
+    location /api/points/ {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;                        
+      proxy_pass http://lines/;
+    }
+
+    location /api/parser/ {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;                        
+      proxy_pass http://parser/;
     }
 
   }


### PR DESCRIPTION
With this setup, each of the APIs are available under the following URL structure:
- `/api/geocoder/`
- `/api/lines/`
- `/api/points/`
- `/api/parser`

@awolfe76, you should only need `/api/geocoder`, but the others are there if you'd like to experiment.
