### PR TITLE
Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,31 +37,9 @@ The site should now be live at `http://localhost:9001`.
 
 ### Docker
 
-The site can also be run as a Docker container.  It hosts a CentOS Nginx server that merges the grasshopper addresspoints API and grasshopper-ui static site into a single site.
+Follow the Docker instructions in the [grasshopper repo](https://github.com/cfpb/grasshopper#docker). 
 
-**Note:** This is currently a very manual process, and geared towards a boot2docker dev environment.  A simpler, more generic Docker setup is coming soon.
-
-1. Add the Elasticsearch and grasshopper addresspoints Docker images.  Follow
-   the instructions from the grasshopper project:
->>>>>>> master
-
-    * https://github.com/cfpb/grasshopper/tree/master/addresspoints#running
-
-1. Import test data into Elasticsearch using the grasshopper-loader:
-
-    * https://github.com/cfpb/grasshopper-loader#usage
-
-1. Build grasshopper-ui static site.
-
-        grunt build
-
-1. Build the grasshopper-ui Docker image.
-
-        docker build --rm -t hmda/grasshopper-ui .
-
-1. Start a grasshopper-ui Docker container:
-
-        docker run -p 80:80 hmda/grasshopper-ui
+**Note** - There is a dev setup for easier development.
 
 
 ## Known issues

--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -8,6 +8,13 @@ module.exports = {
         'connect:livereload',
         'watch'
     ],
+    'docker': [
+        'clean',
+        'copy:dev',
+        'sass:dev',
+        'browserify:dev',
+        'watch'
+    ],
     'build': [
         'clean',
         'copy:build',


### PR DESCRIPTION
Update to grunt for easier docker builds.
Updated readme to point to grasshopper for detailed docker instructions.
