### PR TITLE
Use docker to build the UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,25 @@ MAINTAINER Juan Marin Otero <juan.marin.otero@gmail.com>
 RUN yum -y install epel-release
 RUN yum -y install nginx
 
+# Enable EPEL for Node.js
+# RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+
+# Install npm
+RUN yum install -y npm
+
+# Install grunt-cli
+RUN npm install -g grunt-cli
+
+COPY . /
+
+RUN npm install
+
+# Get node-sass to work
+RUN node ./node_modules/grunt-sass/node_modules/node-sass/scripts/install.js;
+
+RUN grunt build
+
+# grunt builds to dist
 ADD dist /opt/grasshopper-ui/
 
 RUN rm -v /etc/nginx/nginx.conf
@@ -16,5 +35,3 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 EXPOSE 80
 
 CMD /usr/sbin/nginx
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM centos:7
-
 MAINTAINER Juan Marin Otero <juan.marin.otero@gmail.com>
 
 RUN yum -y install epel-release
 RUN yum -y install nginx
 
 # Install npm
-RUN yum install -y npm
+RUN curl --silent --location https://rpm.nodesource.com/setup | bash -
+RUN yum -y install nodejs
+
+RUN mkdir -p /usr/src/app
 
 # Install grunt-cli
 RUN npm install -g grunt-cli
 
-COPY . /
+WORKDIR /usr/src/app
+COPY . /usr/src/app
 
 RUN npm install
 
@@ -19,9 +22,6 @@ RUN npm install
 RUN node ./node_modules/grunt-sass/node_modules/node-sass/scripts/install.js;
 
 RUN grunt build
-
-# grunt builds to dist
-ADD dist /opt/grasshopper-ui/
 
 RUN rm -v /etc/nginx/nginx.conf
 ADD nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ MAINTAINER Juan Marin Otero <juan.marin.otero@gmail.com>
 RUN yum -y install epel-release
 RUN yum -y install nginx
 
-# Enable EPEL for Node.js
-# RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
-
 # Install npm
 RUN yum install -y npm
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,18 +19,6 @@ http {
     server geocoder:8080;
   }
 
-  upstream points {
-    server points:8081;
-  }
-
-  upstream lines {
-    server lines:8082;
-  }
-
-  upstream parser {
-    server parser:5000;
-  }
-
   server {
     listen 80;
     access_log /dev/stdout;
@@ -46,28 +34,6 @@ http {
       proxy_set_header Host $http_host;                        
       proxy_pass http://geocoder/;
     }
-
-    location /api/lines/ {
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;                        
-      proxy_pass http://lines/;
-    }
-
-    location /api/points/ {
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;                        
-      proxy_pass http://points/;
-    }
-
-    location /api/parser/ {
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;                        
-      proxy_pass http://parser/;
-    }
-
   }
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
   
     location / {
       autoindex on;
-      root /opt/grasshopper-ui;
+      root /usr/src/app/dist;
     }
 
     location /api/geocoder/ {


### PR DESCRIPTION
_Didn't focus on the results, just that the build and the api call still worked._

To see it locally you can run the geocoder with `--name`.
`docker run -d -P --name geocoder hmda/geocoder`

And then run the ui with `--link`.
`docker run -d -P --name ui --link geocoder:geocoder hmda/grasshopper-ui`

Not sure if this requires an update to the README, it could but want to see what others think first.

Later, with CORS https://github.com/cfpb/grasshopper/issues/125, we should be able to clean up nginx.conf even more.

Merging this should also lead to a build to help test deployment.

@hkeeler @jmarin 
