### PR TITLE
update grunt-sass dependency to latest (1.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-glob": "^0.1.0",
-    "grunt-sass": "^0.18.1",
+    "grunt-sass": "^1.1.0",
     "load-grunt-config": "^0.16.0"
   },
   "engines": {


### PR DESCRIPTION
The current version (`^0.18.0`) of grunt-sass in `package.json` is out of date. The use of the caret (`^`) means that only minor versions will be installed, so we don't get the latest versions (currently `^1.1.0`). On a new build environment the `npm install` command gives this error:

``` sh
> node-sass@2.1.1 postinstall /Users/chosaka/Projects/chosak-grasshopper-ui/node_modules/node-sass
> node scripts/build.js

module.js:341
    throw err;
    ^

Error: Cannot find module '/Users/chosaka/Projects/chosak-grasshopper-ui/node_modules/node-sass/node_modules/pangyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:139:18)
    at node.js:999:3
Build failed
```

And then the `grunt` command fails with this error:

``` sh
Loading "sass.js" tasks...ERROR
>> Error: `libsass` bindings not found. Try reinstalling `node-sass`?
Warning: Task "sass:dev" not found. Use --force to continue.

Aborted due to warnings.
```

This seems to be happening because v0.18.1 of grunt-sass depends on v2.1.1 of node-sass, which is out of date (see for example [this node-sass issue](https://github.com/sass/node-sass/issues/918#issuecomment-141675757)).

Updating to v1.1.0 of grunt-sass pulls in v3.4.2 of node-sass, which seems to work fine and produces a working build.

cc @awolfe76 
